### PR TITLE
Created `RsError` for error responses

### DIFF
--- a/src/main/java/com/artipie/cargo/http/CargoSlice.java
+++ b/src/main/java/com/artipie/cargo/http/CargoSlice.java
@@ -5,12 +5,17 @@
 package com.artipie.cargo.http;
 
 import com.artipie.http.Slice;
-import com.artipie.http.rs.StandardRs;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rt.ByMethodsRule;
+import com.artipie.http.rt.RtRule;
+import com.artipie.http.rt.RtRulePath;
+import com.artipie.http.rt.SliceRoute;
 import com.artipie.http.slice.SliceSimple;
 
 /**
  * Main cargo repo entry point.
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class CargoSlice extends Slice.Wrap {
 
@@ -18,6 +23,20 @@ public final class CargoSlice extends Slice.Wrap {
      * Ctor.
      */
     public CargoSlice() {
-        super(new SliceSimple(StandardRs.OK));
+        super(
+            new SliceRoute(
+                new RtRulePath(
+                    new RtRule.All(
+                        new RtRule.ByPath("/api/v1/crates/new"),
+                        new ByMethodsRule(RqMethod.PUT)
+                    ),
+                    new PublishSlice()
+                ),
+                new RtRulePath(
+                    RtRule.FALLBACK,
+                    new SliceSimple(new RsError("Endpoint does not exists"))
+                )
+            )
+        );
     }
 }

--- a/src/main/java/com/artipie/cargo/http/PublishSlice.java
+++ b/src/main/java/com/artipie/cargo/http/PublishSlice.java
@@ -1,0 +1,26 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/cargo-adapter/LICENSE
+ */
+package com.artipie.cargo.http;
+
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.commons.lang3.NotImplementedException;
+import org.reactivestreams.Publisher;
+
+/**
+ * Cargo publish slice.
+ * <a href="https://doc.rust-lang.org/cargo/reference/registries.html#publish">Publish endpoint</a>.
+ * @since 0.1
+ */
+public final class PublishSlice implements Slice {
+
+    @Override
+    public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        throw new NotImplementedException("Not implemented yet");
+    }
+}

--- a/src/main/java/com/artipie/cargo/http/RsError.java
+++ b/src/main/java/com/artipie/cargo/http/RsError.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/cargo-adapter/LICENSE
+ */
+package com.artipie.cargo.http;
+
+import com.artipie.http.Response;
+import com.artipie.http.rs.common.RsJson;
+import com.google.common.collect.Lists;
+import java.util.Collection;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonStructure;
+
+/**
+ * Cargo error response.
+ * <a href="https://doc.rust-lang.org/cargo/reference/registries.html#web-api">Documentation</a>.
+ * @since 0.1
+ */
+public final class RsError extends Response.Wrap {
+
+    /**
+     * Ctor.
+     * @param messages Error messages
+     */
+    public RsError(final Collection<String> messages) {
+        super(new RsJson(RsError.format(messages)));
+    }
+
+    /**
+     * Ctor.
+     * @param messages Error messages
+     */
+    public RsError(final String... messages) {
+        this(Lists.newArrayList(messages));
+    }
+
+    /**
+     * Format proper json with provided error messages.
+     * @param messages Error messages
+     * @return Json structure
+     */
+    private static JsonStructure format(final Collection<String> messages) {
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (final String msg : messages) {
+            arr = arr.add(Json.createObjectBuilder().add("detail", msg).build());
+        }
+        return Json.createObjectBuilder().add("errors", arr).build();
+    }
+
+}

--- a/src/test/java/com/artipie/cargo/http/RsErrorTest.java
+++ b/src/test/java/com/artipie/cargo/http/RsErrorTest.java
@@ -11,6 +11,8 @@ import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rs.RsStatus;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -24,8 +26,11 @@ class RsErrorTest {
 
     @Test
     void responseWithOkStatusJsonBodyAndHeader() {
+        final List<String> inp = new LinkedList<>();
+        inp.add("first message");
+        inp.add("second message");
         MatcherAssert.assertThat(
-            new RsError("first message", "second message"),
+            new RsError(inp),
             Matchers.allOf(
                 new RsHasStatus(RsStatus.OK),
                 new RsHasHeaders(

--- a/src/test/java/com/artipie/cargo/http/RsErrorTest.java
+++ b/src/test/java/com/artipie/cargo/http/RsErrorTest.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/cargo-adapter/LICENSE
+ */
+package com.artipie.cargo.http;
+
+import com.artipie.http.headers.ContentLength;
+import com.artipie.http.headers.ContentType;
+import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.rs.RsStatus;
+import java.nio.charset.StandardCharsets;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link RsError}.
+ * @since 0.1
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+class RsErrorTest {
+
+    @Test
+    void responseWithOkStatusJsonBodyAndHeader() {
+        MatcherAssert.assertThat(
+            new RsError("first message", "second message"),
+            Matchers.allOf(
+                new RsHasStatus(RsStatus.OK),
+                new RsHasHeaders(
+                    new ContentType("application/json; charset=UTF-8"),
+                    new ContentLength(67)
+                ),
+                // @checkstyle LineLengthCheck (1 line)
+                new RsHasBody("{\"errors\":[{\"detail\":\"first message\"},{\"detail\":\"second message\"}]}".getBytes(StandardCharsets.UTF_8))
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
Created `RsError` for error responses, added `PublishSlice` skeleton.

Note that in cargo it's recommended to return `OK` in case of error with errors description in json format.