### PR TITLE
Set `yank` field in package metadata

### DIFF
--- a/src/main/java/com/artipie/cargo/meta/MetadataYank.java
+++ b/src/main/java/com/artipie/cargo/meta/MetadataYank.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/cargo-adapter/LICENSE
+ */
+package com.artipie.cargo.meta;
+
+import com.artipie.ArtipieException;
+import com.artipie.asto.ArtipieIOException;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+
+/**
+ * Set `yank` field of the package metadata of the given version to
+ * true or false.
+ * @since 0.1
+ */
+public final class MetadataYank implements
+    BiFunction<Optional<InputStream>, OutputStream, Boolean> {
+
+    /**
+     * Package version.
+     */
+    private final String version;
+
+    /**
+     * Value to set to `yank` field.
+     */
+    private final boolean value;
+
+    /**
+     * Ctor.
+     * @param version Package version
+     * @param value Value to set to `yank` field
+     */
+    public MetadataYank(final String version, final boolean value) {
+        this.version = version;
+        this.value = value;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    public Boolean apply(final Optional<InputStream> input, final OutputStream output) {
+        if (!input.isPresent()) {
+            throw new ArtipieException("Package metadata does not exists!");
+        }
+        final String vers = String.format("\"vers\":\"%s\"", this.version);
+        try (
+            BufferedReader brd = new BufferedReader(new InputStreamReader(input.get()));
+            BufferedWriter bwr = new BufferedWriter(new OutputStreamWriter(output))
+        ) {
+            String line;
+            boolean first = true;
+            boolean found = false;
+            while ((line = brd.readLine()) != null) {
+                if (!first) {
+                    bwr.newLine();
+                }
+                first = false;
+                if (line.contains(vers)) {
+                    found = true;
+                    final JsonObjectBuilder obj = Json.createObjectBuilder(
+                        Json.createReader(new StringReader(line)).readObject()
+                    );
+                    obj.add("yank", this.value);
+                    line = obj.build().toString();
+                }
+                bwr.write(line);
+            }
+            return found;
+        } catch (final IOException err) {
+            throw new ArtipieIOException(err);
+        }
+    }
+}

--- a/src/test/java/com/artipie/cargo/meta/MetadataYankTest.java
+++ b/src/test/java/com/artipie/cargo/meta/MetadataYankTest.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/cargo-adapter/LICENSE
+ */
+package com.artipie.cargo.meta;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link MetadataYank}.
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class MetadataYankTest {
+
+    @Test
+    void updatesYank() {
+        final ByteArrayOutputStream res = new ByteArrayOutputStream();
+        final ByteArrayInputStream input = new ByteArrayInputStream(
+            String.join(
+                System.lineSeparator(),
+                // @checkstyle LineLengthCheck (2 lines)
+                Json.createObjectBuilder().add("name", "test").add("vers", "0.1.2").add("yank", true).build().toString(),
+                Json.createObjectBuilder().add("name", "test").add("vers", "0.2.4").build().toString()
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "Returns true",
+            new MetadataYank("0.1.2", false).apply(Optional.of(input), res),
+            new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+            "Yank is not added",
+            res.toByteArray(),
+            new IsEqual<>(
+                String.join(
+                    System.lineSeparator(),
+                    // @checkstyle LineLengthCheck (2 lines)
+                    Json.createObjectBuilder().add("name", "test").add("vers", "0.1.2").add("yank", false).build().toString(),
+                    Json.createObjectBuilder().add("name", "test").add("vers", "0.2.4").build().toString()
+                ).getBytes(StandardCharsets.UTF_8)
+            )
+        );
+    }
+
+    @Test
+    void addsYank() {
+        final ByteArrayOutputStream res = new ByteArrayOutputStream();
+        final ByteArrayInputStream input = new ByteArrayInputStream(
+            String.join(
+                System.lineSeparator(),
+                // @checkstyle LineLengthCheck (3 lines)
+                Json.createObjectBuilder().add("name", "foo").add("vers", "0.0.1").build().toString(),
+                Json.createObjectBuilder().add("name", "foo").add("vers", "0.0.3").build().toString(),
+                Json.createObjectBuilder().add("name", "foo").add("vers", "0.1.1").build().toString()
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "Returns true",
+            new MetadataYank("0.0.3", true).apply(Optional.of(input), res),
+            new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+            "Yank is not added",
+            res.toByteArray(),
+            new IsEqual<>(
+                String.join(
+                    System.lineSeparator(),
+                    // @checkstyle LineLengthCheck (3 lines)
+                    Json.createObjectBuilder().add("name", "foo").add("vers", "0.0.1").build().toString(),
+                    Json.createObjectBuilder().add("name", "foo").add("vers", "0.0.3").add("yank", true).build().toString(),
+                    Json.createObjectBuilder().add("name", "foo").add("vers", "0.1.1").build().toString()
+                ).getBytes(StandardCharsets.UTF_8)
+            )
+        );
+    }
+
+    @Test
+    void doesNothingIfVersionNotFound() {
+        final ByteArrayOutputStream res = new ByteArrayOutputStream();
+        final byte[] data = String.join(System.lineSeparator(), "a", "b", "123")
+            .getBytes(StandardCharsets.UTF_8);
+        final ByteArrayInputStream input = new ByteArrayInputStream(data);
+        MatcherAssert.assertThat(
+            "Returns false",
+            new MetadataYank("0.1", true).apply(Optional.of(input), res),
+            new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+            "Data are not changed",
+            res.toByteArray(),
+            new IsEqual<>(data)
+        );
+    }
+
+}


### PR DESCRIPTION
Part of #15 
Added class to `yank` package metadata. This class will be used in `yank` endpoint for metadata update.